### PR TITLE
Using most of router.params fn

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 
 module.exports = function(router) {
-  return function(name, handler) {
-    return router.param(name, function(req, res, next, val) {
-      var newVal;
-      if (typeof handler === 'function') {
-        if (!(newVal = handler(val))) {
+  return function(paramName, handler) {
+    return router.param(paramName, function(req, res, next, val, name) {
+      if (handler instanceof Function) {
+        var newVal = handler(val)
+        if (!newVal) {
           return next('route'); // bypass current route
         }
         req.params[name] = newVal;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-params-handler",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Express.js params handler",
   "main": "index.js",
   "dependencies": {},

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ describe('express-params-handler', function() {
         done()
       }
 
-      app.params['id'](req, res, next, '100')
+      app.params['id'](req, res, next, '100', 'id')
     })
 
     it('negative', function(done) {
@@ -42,7 +42,7 @@ describe('express-params-handler', function() {
         done()
       }
 
-      app.params['id'](req, res, next, 'kraken')
+      app.params['id'](req, res, next, 'kraken', 'id')
     })
 
   })
@@ -59,7 +59,7 @@ describe('express-params-handler', function() {
         done()
       }
 
-      app.params['date'](req, res, next, '2015-07-30')
+      app.params['date'](req, res, next, '2015-07-30', 'date')
     })
 
     it('negative', function(done) {
@@ -71,7 +71,7 @@ describe('express-params-handler', function() {
         done()
       }
 
-      app.params['date'](req, res, next, 'kraken')
+      app.params['date'](req, res, next, 'kraken', 'date')
     })
 
   })
@@ -82,7 +82,7 @@ describe('express-params-handler', function() {
     it('should complain', function() {
       assert.throws(function() {
         lib(app)('id', 'what?')
-        app.params['id'](req, res, next, 'whatever')
+        app.params['id'](req, res, next, 'whatever', 'id')
       }, /Unsupported param handler/)
     })
 


### PR DESCRIPTION
Add `key` to the `router.param('id', function(req, res, next, val, key) {})` call