### PR TITLE
Simplify params handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var expressParams = require('express-params-handler')
 var app = express()
 
 app.param('id', expressParams(Number))
-app.param('date', expressParams(/^\d{4}-\d{2}-\d(2)$/))
+app.param('date', expressParams(/^\d{4}-\d{2}-\d{2}$/))
 
 app.get('/by-id/:id', function(req, res, next) {
   // req.params.id will be a number

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ express-params-handler
 
 Express.js v4+ params handler
 
-This lib is replacement of [express-params](https://www.npmjs.com/package/express-params) which is made for Express 2.5. Express v4+ deprecated number of features which are in use of that original library. This lib offers similar functionality but doesn't use deprecated methods of new Express.
+This lib is replacement of [express-params](https://www.npmjs.com/package/express-params) which is made for
+Express 2.5. Express v4+ deprecated number of features which are in use of that original library. This lib
+offers similar functionality but doesn't use deprecated methods of new Express.
 
 
 ## Installation
@@ -17,20 +19,21 @@ This lib is replacement of [express-params](https://www.npmjs.com/package/expres
 var expressParams = require('express-params-handler')
 
 var app = express()
-expressParams(app)('id', Number)
-expressParams(app)('date', /^\d{4}-\d{2}-\d(2)$/)
 
-app.get('/:id', function(req, res, next) {
+app.param('id', expressParams(Number))
+app.param('date', expressParams(/^\d{4}-\d{2}-\d(2)$/))
+
+app.get('/by-id/:id', function(req, res, next) {
   // req.params.id will be a number
 })
 
-app.get('/:date', function(req, res, next) { 
+app.get('/by-date/:date', function(req, res, next) {
   // req.params.date will be a string with YYYY-MM-DD format
 })
 
 ```
 
 
-## Licence 
+## Licence
 
 MIT

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = function(handler) {
     throw new Error('Unsupported param handler. Either function or Regexp expected')
 
   return function(req, res, next, val, name) {
+    val = req.params[name]
 
     if (handler instanceof Function) {
       var newVal = handler(val)
@@ -14,7 +15,6 @@ module.exports = function(handler) {
     } else if (handler instanceof RegExp) {
       if (!handler.test(val))
         return next('route') // bypass current route
-      req.params[name] = val
 
     } else {
       throw new Error('Should not reach here')

--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
 
-module.exports = function(router) {
-  return function(paramName, handler) {
-    return router.param(paramName, function(req, res, next, val, name) {
-      if (handler instanceof Function) {
-        var newVal = handler(val)
-        if (!newVal) {
-          return next('route'); // bypass current route
-        }
-        req.params[name] = newVal;
-      } else if (handler instanceof RegExp) {
-        if (!handler.test(val)) {
-          return next('route'); // bypass current route
-        }
-        req.params[name] = val;
-      } else {
-        throw new Error('Unsupported param handler. Either function or Regexp expected');
-      }
-      return next();
-    });
-  };
-};
+module.exports = function(handler) {
+  if (!(handler instanceof Function || handler instanceof RegExp))
+    throw new Error('Unsupported param handler. Either function or Regexp expected')
+
+  return function(req, res, next, val, name) {
+
+    if (handler instanceof Function) {
+      var newVal = handler(val)
+      if (!newVal)
+        return next('route'); // bypass current route
+      req.params[name] = newVal
+
+    } else if (handler instanceof RegExp) {
+      if (!handler.test(val))
+        return next('route') // bypass current route
+      req.params[name] = val
+
+    } else {
+      throw new Error('Should not reach here')
+    }
+
+    return next();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "express-params-handler",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Express.js params handler",
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "mocha": "latest"
+    "express": "^4.13.3",
+    "mocha": "latest",
+    "supertest": "^1.1.0"
   },
   "scripts": {
     "test": "mocha --recursive"
@@ -19,6 +21,9 @@
     "express-validation"
   ],
   "author": "Dmitry Shirokov <deadrunk@gmail.com>",
+  "contributors": [
+    "Dmitry Kirilyuk @Jokero"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Adslot/node-express-params-handler/issues"


### PR DESCRIPTION
 - Use standard app.params
 - Update README with new examples
 - Use supertest